### PR TITLE
Add Xquik X data tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repository contains **20+ specialized tools and functions** designed to enh
 - **Perplexica Search** - Web search using Perplexica API with citations
 - **Pexels Media Search** - High-quality photos and videos from Pexels API
 - **YouTube Search & Embed** - Search YouTube and play videos in embedded player
+- **Xquik X Data Tool** - Search and look up X posts, users, timelines, and trends
 - **Native Image Generator** - Direct Open WebUI image generation with Ollama model management
 - **Hugging Face Image Generator** - AI-powered image creation
 - **ComfyUI Image-to-Image (Qwen Edit 2509)** - Advanced image editing with multi-image support
@@ -111,29 +112,30 @@ Most tools are designed to work with minimal configuration. Key configuration ar
 11. [ComfyUI ACE Step Audio Tool (Legacy)](#comfyui-ace-step-audio-tool-legacy)
 12. [ComfyUI Text-to-Video Tool](#comfyui-text-to-video-tool)
 13. [OpenWeatherMap Forecast Tool](#openweathermap-forecast-tool)
-14. [Flux Kontext ComfyUI Pipe](#flux-kontext-comfyui-pipe)
-15. [Google Veo Text-to-Video & Image-to-Video Pipe](#google-veo-text-to-video--image-to-video-pipe)
-16. [MiniMax LLM Pipe](#minimax-llm-pipe)
-17. [Planner Agent v3](#planner-agent-v3)
-18. [arXiv Research MCTS Pipe](#arxiv-research-mcts-pipe)
-19. [Multi Model Conversations v2 Pipe](#multi-model-conversations-v2-pipe)
-20. [Resume Analyzer Pipe](#resume-analyzer-pipe)
-21. [Mopidy Music Controller](#mopidy-music-controller)
-22. [Letta Agent Pipe](#letta-agent-pipe)
-23. [Perplexica Pipe](#perplexica-pipe)
-24. [OpenRouter Image Pipe](#openrouter-image-pipe)
-25. [OpenRouter WebSearch Citations Filter](#openrouter-websearch-citations-filter)
-26. [Doodle Paint Filter](#doodle-paint-filter)
-27. [Prompt Enhancer Filter](#prompt-enhancer-filter)
-28. [Semantic Router Filter](#semantic-router-filter)
-29. [Full Document Filter](#full-document-filter)
-30. [Clean Thinking Tags Filter](#clean-thinking-tags-filter)
-31. [Using the Provided ComfyUI Workflows](#using-the-provided-comfyui-workflows)
-32. [Installation](#installation)
-33. [Contributing](#contributing)
-34. [License](#license)
-35. [Credits](#credits)
-36. [Support](#support)
+14. [Xquik X Data Tool](#xquik-x-data-tool)
+15. [Flux Kontext ComfyUI Pipe](#flux-kontext-comfyui-pipe)
+16. [Google Veo Text-to-Video & Image-to-Video Pipe](#google-veo-text-to-video--image-to-video-pipe)
+17. [MiniMax LLM Pipe](#minimax-llm-pipe)
+18. [Planner Agent v3](#planner-agent-v3)
+19. [arXiv Research MCTS Pipe](#arxiv-research-mcts-pipe)
+20. [Multi Model Conversations v2 Pipe](#multi-model-conversations-v2-pipe)
+21. [Resume Analyzer Pipe](#resume-analyzer-pipe)
+22. [Mopidy Music Controller](#mopidy-music-controller)
+23. [Letta Agent Pipe](#letta-agent-pipe)
+24. [Perplexica Pipe](#perplexica-pipe)
+25. [OpenRouter Image Pipe](#openrouter-image-pipe)
+26. [OpenRouter WebSearch Citations Filter](#openrouter-websearch-citations-filter)
+27. [Doodle Paint Filter](#doodle-paint-filter)
+28. [Prompt Enhancer Filter](#prompt-enhancer-filter)
+29. [Semantic Router Filter](#semantic-router-filter)
+30. [Full Document Filter](#full-document-filter)
+31. [Clean Thinking Tags Filter](#clean-thinking-tags-filter)
+32. [Using the Provided ComfyUI Workflows](#using-the-provided-comfyui-workflows)
+33. [Installation](#installation)
+34. [Contributing](#contributing)
+35. [License](#license)
+36. [Credits](#credits)
+37. [Support](#support)
 ---
 
 ## 🧪 Tools
@@ -810,6 +812,53 @@ Tool that fetches weather forecasts using the OpenWeatherMap API and displays an
 
 ![OpenWeatherMap Forecast Tool](img/openweathermap_tool.png)
 *Example OpenWeatherMap Forecast Tool widget*
+
+---
+
+### Xquik X Data Tool
+
+### Description
+
+Search and look up X posts, users, timelines, and trends through the Xquik API. This tool is read-only and returns structured JSON so Open WebUI models can inspect source text, authors, metrics, pagination fields, and trend metadata.
+
+### Configuration
+
+- `XQUIK_API_KEY` (str): Xquik API key for authenticated read requests
+- `BASE_URL` (str): Xquik API base URL (default: `https://xquik.com/api/v1`)
+- `DEFAULT_LIMIT` (int): Default result limit for list endpoints (default: 10)
+- `REQUEST_TIMEOUT_SECONDS` (int): Request timeout in seconds (default: 30)
+
+**Prerequisites**: Create a Xquik API key at [xquik.com](https://xquik.com) for authenticated read requests.
+
+### Usage
+
+- **Search X Posts:**
+
+  ```python
+  Search X for "open webui lang:en" with the latest results
+  ```
+
+- **Look Up a User:**
+
+  ```python
+  Look up the X user openwebui
+  ```
+
+- **Get Trends:**
+
+  ```python
+  Get worldwide X trends
+  ```
+
+### Features
+
+- **Post Search**: Uses X search operators with Latest or Top ordering
+- **Post Lookup**: Fetches a single post by numeric ID
+- **User Search**: Searches X users by name or username
+- **User Lookup**: Fetches user profile details by ID or username
+- **User Timelines**: Lists recent user posts with optional replies and parent posts
+- **Trends**: Fetches regional X trends by WOEID
+- **Structured Output**: Returns JSON responses for reliable model analysis
 
 ---
 

--- a/tools/xquik_x_data_tool.py
+++ b/tools/xquik_x_data_tool.py
@@ -1,0 +1,252 @@
+"""
+title: Xquik X Data Tool
+description: Search and look up X posts, users, timelines, and trends using the Xquik API
+author: Xquik
+author_url: https://github.com/Xquik-dev/x-twitter-scraper
+funding_url: https://xquik.com
+requirements:aiohttp
+version: 0.1.0
+license: MIT
+"""
+
+import json
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+import aiohttp
+from pydantic import BaseModel, Field
+
+
+async def emit_status(
+    event_emitter: Optional[Callable[[Any], Awaitable[None]]],
+    description: str,
+    done: bool = False,
+) -> None:
+    """Emit Open WebUI status events when an event emitter is available."""
+    if event_emitter:
+        await event_emitter(
+            {"type": "status", "data": {"description": description, "done": done}}
+        )
+
+
+class Tools:
+    class Valves(BaseModel):
+        XQUIK_API_KEY: str = Field(
+            default="",
+            description="Xquik API key for authenticated read requests",
+            json_schema_extra={"input": {"type": "password"}},
+        )
+        BASE_URL: str = Field(
+            default="https://xquik.com/api/v1",
+            description="Xquik API base URL",
+        )
+        DEFAULT_LIMIT: int = Field(
+            default=10,
+            description="Default result limit for list endpoints",
+        )
+        REQUEST_TIMEOUT_SECONDS: int = Field(
+            default=30,
+            description="HTTP request timeout in seconds",
+        )
+
+    def __init__(self) -> None:
+        self.valves = self.Valves()
+        self.citation = False
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {
+            "accept": "application/json",
+            "xquik-api-contract": "2026-04-29",
+        }
+        if self.valves.XQUIK_API_KEY:
+            headers["x-api-key"] = self.valves.XQUIK_API_KEY
+        return headers
+
+    async def _get_json(self, path: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        base_url = self.valves.BASE_URL.rstrip("/")
+        timeout = aiohttp.ClientTimeout(total=self.valves.REQUEST_TIMEOUT_SECONDS)
+
+        clean_params = {
+            key: value
+            for key, value in params.items()
+            if value is not None and value != ""
+        }
+
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(
+                f"{base_url}{path}",
+                headers=self._headers(),
+                params=clean_params,
+            ) as response:
+                content_type = response.headers.get("content-type", "")
+                if "application/json" in content_type:
+                    data = await response.json()
+                else:
+                    data = {"message": await response.text()}
+
+                if response.status >= 400:
+                    return {
+                        "ok": False,
+                        "status": response.status,
+                        "error": data,
+                    }
+
+                return {"ok": True, "status": response.status, "data": data}
+
+    def _format_response(self, title: str, payload: Dict[str, Any]) -> str:
+        if not payload["ok"]:
+            return (
+                f"{title} failed with HTTP {payload['status']}.\n\n"
+                f"{json.dumps(payload['error'], indent=2, ensure_ascii=False)}"
+            )
+
+        return (
+            f"{title}\n\n"
+            f"```json\n{json.dumps(payload['data'], indent=2, ensure_ascii=False)}\n```"
+        )
+
+    async def search_tweets(
+        self,
+        query: str,
+        limit: Optional[int] = None,
+        query_type: str = "Latest",
+        cursor: Optional[str] = None,
+        since_time: Optional[str] = None,
+        until_time: Optional[str] = None,
+        __event_emitter__: Optional[Callable[[Any], Awaitable[None]]] = None,
+    ) -> str:
+        """
+        Search X posts with X search operators and cursor pagination.
+
+        Args:
+            query: Search query, such as keywords, hashtags, from:user, or exact phrases.
+            limit: Maximum posts to return. Defaults to the configured limit.
+            query_type: Sort order. Use Latest or Top.
+            cursor: Pagination cursor from a prior response.
+            since_time: ISO 8601 timestamp for the lower time bound.
+            until_time: ISO 8601 timestamp for the upper time bound.
+        """
+        result_limit = max(1, min(limit or self.valves.DEFAULT_LIMIT, 200))
+        sort_order = "Top" if query_type.lower() == "top" else "Latest"
+
+        await emit_status(__event_emitter__, f"Searching X posts for: {query}")
+        payload = await self._get_json(
+            "/x/tweets/search",
+            {
+                "q": query,
+                "limit": result_limit,
+                "queryType": sort_order,
+                "cursor": cursor,
+                "sinceTime": since_time,
+                "untilTime": until_time,
+            },
+        )
+        await emit_status(__event_emitter__, "X post search finished", done=True)
+        return self._format_response(f"X post search results for '{query}'", payload)
+
+    async def lookup_tweet(
+        self,
+        tweet_id: str,
+        __event_emitter__: Optional[Callable[[Any], Awaitable[None]]] = None,
+    ) -> str:
+        """
+        Look up one X post by numeric post ID.
+
+        Args:
+            tweet_id: Numeric X post ID.
+        """
+        await emit_status(__event_emitter__, f"Looking up X post: {tweet_id}")
+        payload = await self._get_json(f"/x/tweets/{tweet_id}", {})
+        await emit_status(__event_emitter__, "X post lookup finished", done=True)
+        return self._format_response(f"X post {tweet_id}", payload)
+
+    async def search_users(
+        self,
+        query: str,
+        cursor: Optional[str] = None,
+        __event_emitter__: Optional[Callable[[Any], Awaitable[None]]] = None,
+    ) -> str:
+        """
+        Search X users by name or username.
+
+        Args:
+            query: Name, username, or keyword to search.
+            cursor: Pagination cursor from a prior response.
+        """
+        await emit_status(__event_emitter__, f"Searching X users for: {query}")
+        payload = await self._get_json(
+            "/x/users/search",
+            {"q": query, "cursor": cursor},
+        )
+        await emit_status(__event_emitter__, "X user search finished", done=True)
+        return self._format_response(f"X user search results for '{query}'", payload)
+
+    async def get_user(
+        self,
+        user_id_or_username: str,
+        __event_emitter__: Optional[Callable[[Any], Awaitable[None]]] = None,
+    ) -> str:
+        """
+        Look up an X user by numeric ID or username.
+
+        Args:
+            user_id_or_username: Numeric user ID or username without @.
+        """
+        await emit_status(
+            __event_emitter__, f"Looking up X user: {user_id_or_username}"
+        )
+        payload = await self._get_json(f"/x/users/{user_id_or_username}", {})
+        await emit_status(__event_emitter__, "X user lookup finished", done=True)
+        return self._format_response(f"X user {user_id_or_username}", payload)
+
+    async def get_user_tweets(
+        self,
+        user_id_or_username: str,
+        cursor: Optional[str] = None,
+        include_replies: bool = False,
+        include_parent_tweet: bool = False,
+        __event_emitter__: Optional[Callable[[Any], Awaitable[None]]] = None,
+    ) -> str:
+        """
+        List recent posts for an X user.
+
+        Args:
+            user_id_or_username: Numeric user ID or username without @.
+            cursor: Pagination cursor from a prior response.
+            include_replies: Include reply posts.
+            include_parent_tweet: Include parent post data for replies.
+        """
+        await emit_status(
+            __event_emitter__, f"Fetching posts for X user: {user_id_or_username}"
+        )
+        payload = await self._get_json(
+            f"/x/users/{user_id_or_username}/tweets",
+            {
+                "cursor": cursor,
+                "includeReplies": include_replies,
+                "includeParentTweet": include_parent_tweet,
+            },
+        )
+        await emit_status(__event_emitter__, "X user posts finished", done=True)
+        return self._format_response(f"Posts for X user {user_id_or_username}", payload)
+
+    async def get_trends(
+        self,
+        woeid: int = 1,
+        count: int = 30,
+        __event_emitter__: Optional[Callable[[Any], Awaitable[None]]] = None,
+    ) -> str:
+        """
+        Get trending X topics for a region.
+
+        Args:
+            woeid: Yahoo WOEID region code. Use 1 for worldwide.
+            count: Number of trends to return, from 1 to 50.
+        """
+        trend_count = max(1, min(count, 50))
+        await emit_status(__event_emitter__, f"Fetching X trends for WOEID {woeid}")
+        payload = await self._get_json(
+            "/trends",
+            {"woeid": woeid, "count": trend_count},
+        )
+        await emit_status(__event_emitter__, "X trends finished", done=True)
+        return self._format_response(f"X trends for WOEID {woeid}", payload)


### PR DESCRIPTION
## Summary

- Add a standalone Open WebUI tool for Xquik read endpoints.
- Document configuration and usage in the README and table of contents.
- Expose post search, post lookup, user search, user lookup, user posts, and trends.

## Validation

- python3 -m py_compile tools/xquik_x_data_tool.py
- Import check with aiohttp and pydantic installed through uv
- git diff check

## Duplicate checks

- No existing Xquik entries in the target default branch code search.
- No open or closed target PRs or issues for Xquik, x-twitter-scraper, xquik.com, or Xquik-dev.
