### PR TITLE
feat: add Atlas Cloud media generation tool

### DIFF
--- a/tests/test_atlascloud_media_tool.py
+++ b/tests/test_atlascloud_media_tool.py
@@ -1,0 +1,189 @@
+"""Unit tests for the Atlas Cloud media tool."""
+
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+
+from atlascloud_media_tool import (
+    DEFAULT_IMAGE_MODEL,
+    DEFAULT_VIDEO_MODEL,
+    AtlasCloudError,
+    Tools,
+)
+
+
+class FakeResponse:
+    def __init__(self, payload, status=200):
+        self.payload = payload
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    async def json(self):
+        return self.payload
+
+    async def text(self):
+        return str(self.payload)
+
+
+class FakeSession:
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.requests = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    def post(self, url, json):
+        self.requests.append(("POST", url, json))
+        return next(self.responses)
+
+    def get(self, url):
+        self.requests.append(("GET", url, None))
+        return next(self.responses)
+
+
+def test_default_valves_use_current_atlas_models():
+    tool = Tools()
+
+    assert tool.valves.API_BASE_URL == "https://api.atlascloud.ai/api/v1"
+    assert tool.valves.IMAGE_MODEL == DEFAULT_IMAGE_MODEL
+    assert tool.valves.VIDEO_MODEL == DEFAULT_VIDEO_MODEL
+
+
+@pytest.mark.asyncio
+async def test_missing_api_key_is_reported():
+    tool = Tools()
+    emitter = AsyncMock()
+
+    result = await tool.generate_image("a lighthouse", __event_emitter__=emitter)
+
+    assert "API key is not configured" in result
+    assert emitter.await_args_list[-1].args[0]["data"]["done"] is True
+
+
+@pytest.mark.asyncio
+async def test_generate_image_submits_polls_and_formats_outputs():
+    tool = Tools()
+    tool.valves.ATLASCLOUD_API_KEY = "test-key"
+    session = FakeSession(
+        [
+            FakeResponse(
+                {"code": 200, "data": {"id": "prediction-1", "status": "starting"}}
+            ),
+            FakeResponse({"code": 200, "data": {"status": "processing"}}),
+            FakeResponse(
+                {
+                    "code": 200,
+                    "data": {
+                        "status": "completed",
+                        "outputs": ["https://cdn.example.test/image.jpg"],
+                    },
+                }
+            ),
+        ]
+    )
+
+    with patch(
+        "atlascloud_media_tool.aiohttp.ClientSession", return_value=session
+    ), patch("atlascloud_media_tool.asyncio.sleep", new=AsyncMock()):
+        result = await tool.generate_image("a lighthouse")
+
+    assert "![Generated image](https://cdn.example.test/image.jpg)" in result
+    assert session.requests[0] == (
+        "POST",
+        "https://api.atlascloud.ai/api/v1/model/generateImage",
+        {
+            "model": DEFAULT_IMAGE_MODEL,
+            "prompt": "a lighthouse",
+            "size": "2048*2048",
+            "output_format": "jpeg",
+        },
+    )
+    assert session.requests[1][1].endswith("/model/prediction/prediction-1")
+
+
+@pytest.mark.asyncio
+async def test_generate_video_submits_expected_options_and_formats_output():
+    tool = Tools()
+    tool.valves.ATLASCLOUD_API_KEY = "test-key"
+    session = FakeSession(
+        [
+            FakeResponse({"data": {"id": "prediction-video"}}),
+            FakeResponse(
+                {
+                    "data": {
+                        "status": "completed",
+                        "outputs": ["https://cdn.example.test/video.mp4"],
+                    }
+                }
+            ),
+        ]
+    )
+
+    with patch("atlascloud_media_tool.aiohttp.ClientSession", return_value=session):
+        result = await tool.generate_video(
+            "a city at night",
+            duration=8,
+            resolution="1080p",
+            ratio="16:9",
+            generate_audio=False,
+        )
+
+    assert "[Download generated video](https://cdn.example.test/video.mp4)" in result
+    assert session.requests[0] == (
+        "POST",
+        "https://api.atlascloud.ai/api/v1/model/generateVideo",
+        {
+            "model": DEFAULT_VIDEO_MODEL,
+            "prompt": "a city at night",
+            "duration": 8,
+            "resolution": "1080p",
+            "ratio": "16:9",
+            "generate_audio": False,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_prediction_is_reported():
+    tool = Tools()
+    tool.valves.ATLASCLOUD_API_KEY = "test-key"
+    session = FakeSession(
+        [
+            FakeResponse({"data": {"id": "prediction-2"}}),
+            FakeResponse({"data": {"status": "failed", "error": "model unavailable"}}),
+        ]
+    )
+
+    with patch("atlascloud_media_tool.aiohttp.ClientSession", return_value=session):
+        result = await tool.generate_video("a city at night")
+
+    assert "model unavailable" in result
+
+
+def test_invalid_data_payload_raises_clear_error():
+    with pytest.raises(AtlasCloudError, match="invalid response payload"):
+        Tools._data({"data": []})
+
+
+def test_api_error_code_raises_clear_error():
+    with pytest.raises(AtlasCloudError, match="insufficient balance"):
+        Tools._data({"code": 402, "message": "insufficient balance"})
+
+
+@pytest.mark.asyncio
+async def test_non_object_json_response_raises_clear_error():
+    with pytest.raises(AtlasCloudError, match="invalid JSON payload"):
+        await Tools._json_response(FakeResponse([]))

--- a/tools/atlascloud_media_tool.py
+++ b/tools/atlascloud_media_tool.py
@@ -1,0 +1,244 @@
+"""
+title: Atlas Cloud Media Generator
+description: Generate images and videos through the Atlas Cloud Media API.
+author: binyangzhu000-sudo
+author_url: https://github.com/binyangzhu000-sudo
+version: 1.0.0
+license: MIT
+"""
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any, Optional
+
+import aiohttp
+from pydantic import BaseModel, Field
+
+IMAGE_ENDPOINT = "/model/generateImage"
+VIDEO_ENDPOINT = "/model/generateVideo"
+DEFAULT_IMAGE_MODEL = "bytedance/seedream-v5.0-pro/text-to-image"
+DEFAULT_VIDEO_MODEL = "bytedance/seedance-2.0-fast/text-to-video"
+COMPLETED_STATUSES = frozenset({"completed", "succeeded", "success"})
+FAILED_STATUSES = frozenset({"failed", "error", "cancelled", "canceled", "timeout"})
+
+EventEmitter = Optional[Callable[[dict[str, Any]], Awaitable[None]]]
+
+
+class AtlasCloudError(RuntimeError):
+    """Raised when Atlas Cloud rejects or fails a generation request."""
+
+
+class Tools:
+    class Valves(BaseModel):
+        ATLASCLOUD_API_KEY: str = Field(
+            default="",
+            description="Atlas Cloud API key.",
+            json_schema_extra={"input": {"type": "password"}},
+        )
+        API_BASE_URL: str = Field(
+            default="https://api.atlascloud.ai/api/v1",
+            description="Atlas Cloud Media API base URL.",
+        )
+        IMAGE_MODEL: str = Field(
+            default=DEFAULT_IMAGE_MODEL,
+            description="Default Atlas Cloud text-to-image model ID.",
+        )
+        VIDEO_MODEL: str = Field(
+            default=DEFAULT_VIDEO_MODEL,
+            description="Default Atlas Cloud text-to-video model ID.",
+        )
+        POLL_INTERVAL_SECONDS: float = Field(default=3.0, ge=0.1)
+        GENERATION_TIMEOUT_SECONDS: float = Field(default=600.0, ge=1.0)
+
+    def __init__(self) -> None:
+        self.valves = self.Valves()
+
+    async def _emit_status(
+        self,
+        emitter: EventEmitter,
+        description: str,
+        *,
+        done: bool,
+    ) -> None:
+        if emitter:
+            await emitter(
+                {
+                    "type": "status",
+                    "data": {"description": description, "done": done},
+                }
+            )
+
+    @staticmethod
+    async def _json_response(response: aiohttp.ClientResponse) -> dict[str, Any]:
+        try:
+            payload = await response.json()
+        except (aiohttp.ContentTypeError, ValueError) as exc:
+            body = (await response.text()).strip()
+            raise AtlasCloudError(
+                f"Atlas Cloud returned a non-JSON response ({response.status}): {body[:300]}"
+            ) from exc
+
+        if not isinstance(payload, dict):
+            raise AtlasCloudError("Atlas Cloud returned an invalid JSON payload.")
+
+        if response.status >= 400:
+            detail = payload.get("message") or payload.get("error") or payload
+            raise AtlasCloudError(
+                f"Atlas Cloud request failed ({response.status}): {detail}"
+            )
+        return payload
+
+    @staticmethod
+    def _data(payload: dict[str, Any]) -> dict[str, Any]:
+        code = payload.get("code")
+        if code not in (None, 0, 200):
+            detail = payload.get("message") or payload.get("error") or f"code {code}"
+            raise AtlasCloudError(f"Atlas Cloud request failed: {detail}")
+        data = payload.get("data", payload)
+        if not isinstance(data, dict):
+            raise AtlasCloudError("Atlas Cloud returned an invalid response payload.")
+        return data
+
+    async def _submit_and_wait(
+        self,
+        endpoint: str,
+        payload: dict[str, Any],
+        emitter: EventEmitter,
+    ) -> list[str]:
+        api_key = self.valves.ATLASCLOUD_API_KEY.strip()
+        if not api_key:
+            raise AtlasCloudError(
+                "Atlas Cloud API key is not configured in the tool Valves."
+            )
+
+        base_url = self.valves.API_BASE_URL.rstrip("/")
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        timeout = aiohttp.ClientTimeout(
+            total=self.valves.GENERATION_TIMEOUT_SECONDS + 30
+        )
+
+        async with aiohttp.ClientSession(timeout=timeout, headers=headers) as session:
+            async with session.post(f"{base_url}{endpoint}", json=payload) as response:
+                submit_data = self._data(await self._json_response(response))
+
+            prediction_id = submit_data.get("id") or submit_data.get("request_id")
+            if not prediction_id:
+                raise AtlasCloudError("Atlas Cloud did not return a prediction ID.")
+
+            deadline = time.monotonic() + self.valves.GENERATION_TIMEOUT_SECONDS
+            while time.monotonic() < deadline:
+                async with session.get(
+                    f"{base_url}/model/prediction/{prediction_id}"
+                ) as response:
+                    prediction = self._data(await self._json_response(response))
+
+                status = str(prediction.get("status", "")).lower()
+                if status in COMPLETED_STATUSES:
+                    outputs = (
+                        prediction.get("outputs") or prediction.get("output") or []
+                    )
+                    if isinstance(outputs, str):
+                        outputs = [outputs]
+                    if not isinstance(outputs, list) or not all(
+                        isinstance(item, str) for item in outputs
+                    ):
+                        raise AtlasCloudError(
+                            "Atlas Cloud returned invalid output URLs."
+                        )
+                    if not outputs:
+                        raise AtlasCloudError(
+                            "Atlas Cloud completed without output URLs."
+                        )
+                    return outputs
+
+                if status in FAILED_STATUSES:
+                    detail = (
+                        prediction.get("error") or prediction.get("message") or status
+                    )
+                    raise AtlasCloudError(f"Atlas Cloud generation failed: {detail}")
+
+                await self._emit_status(
+                    emitter,
+                    f"Atlas Cloud generation status: {status or 'processing'}",
+                    done=False,
+                )
+                await asyncio.sleep(self.valves.POLL_INTERVAL_SECONDS)
+
+        raise AtlasCloudError("Atlas Cloud generation timed out.")
+
+    async def generate_image(
+        self,
+        prompt: str,
+        size: str = "2048*2048",
+        output_format: str = "jpeg",
+        __event_emitter__: EventEmitter = None,
+    ) -> str:
+        """Generate an image from a text prompt with Atlas Cloud."""
+        await self._emit_status(
+            __event_emitter__, "Generating image with Atlas Cloud", done=False
+        )
+        try:
+            outputs = await self._submit_and_wait(
+                IMAGE_ENDPOINT,
+                {
+                    "model": self.valves.IMAGE_MODEL,
+                    "prompt": prompt,
+                    "size": size,
+                    "output_format": output_format,
+                },
+                __event_emitter__,
+            )
+        except (AtlasCloudError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            await self._emit_status(
+                __event_emitter__, f"Atlas Cloud error: {exc}", done=True
+            )
+            return f"Atlas Cloud image generation failed: {exc}"
+
+        await self._emit_status(
+            __event_emitter__, "Atlas Cloud image generated", done=True
+        )
+        images = "\n".join(f"![Generated image]({url})" for url in outputs)
+        links = "\n".join(f"- {url}" for url in outputs)
+        return f"{images}\n\nDownload links:\n{links}"
+
+    async def generate_video(
+        self,
+        prompt: str,
+        duration: int = 5,
+        resolution: str = "720p",
+        ratio: str = "adaptive",
+        generate_audio: bool = True,
+        __event_emitter__: EventEmitter = None,
+    ) -> str:
+        """Generate a video from a text prompt with Atlas Cloud."""
+        await self._emit_status(
+            __event_emitter__, "Generating video with Atlas Cloud", done=False
+        )
+        try:
+            outputs = await self._submit_and_wait(
+                VIDEO_ENDPOINT,
+                {
+                    "model": self.valves.VIDEO_MODEL,
+                    "prompt": prompt,
+                    "duration": duration,
+                    "resolution": resolution,
+                    "ratio": ratio,
+                    "generate_audio": generate_audio,
+                },
+                __event_emitter__,
+            )
+        except (AtlasCloudError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            await self._emit_status(
+                __event_emitter__, f"Atlas Cloud error: {exc}", done=True
+            )
+            return f"Atlas Cloud video generation failed: {exc}"
+
+        await self._emit_status(
+            __event_emitter__, "Atlas Cloud video generated", done=True
+        )
+        links = "\n".join(f"- [Download generated video]({url})" for url in outputs)
+        return f"Generated video:\n{links}"


### PR DESCRIPTION
## Summary

- add a standalone Open WebUI tool for Atlas Cloud image and video generation
- support configurable API credentials, base URL, default models, polling, and status events
- handle API, prediction, timeout, and malformed-response failures with user-facing messages
- add focused tests for image/video payloads, polling, outputs, and error paths

## Validation

- `python3 -m pytest -q` (`44 passed, 3 skipped`)
- `python3 -m pytest -q tests/test_atlascloud_media_tool.py` (`8 passed`)
- `uvx black --check tools/atlascloud_media_tool.py tests/test_atlascloud_media_tool.py`
- `uvx ruff check --ignore UP045 tools/atlascloud_media_tool.py tests/test_atlascloud_media_tool.py` (keeps Python 3.9-compatible `Optional`)
- `python3 -m compileall -q tools/atlascloud_media_tool.py tests/test_atlascloud_media_tool.py`
- `git diff --check`
- Atlas Cloud public catalog returned HTTP 200; verified the configured Seedream and Seedance model IDs

No README, docs, logo, sponsor, credits, or partner changes.