### PR TITLE
Refresh MiniMax model parameters and multimodal input

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This repository contains **20+ specialized tools and functions** designed to enh
 - **Letta Agent** - Autonomous agent integration
 - **Perplexica Pipe** - AI-powered web search with streaming responses and citations
 - **Google Veo Text-to-Video & Image-to-Video** - Generate videos from text or a single image using Google Veo (only one image supported as input)
-- **MiniMax LLM Pipe** - Route chat completions to MiniMax's OpenAI-compatible API with M3 (512K context), M2.7, and M2.7-highspeed models
+- **MiniMax LLM Pipe** - Route chat completions to MiniMax's OpenAI-compatible API with M3 (1M context, image/video input) and M2.7 models
 
 ### 🔧 **Filters**
 
@@ -944,7 +944,7 @@ Prompt: "Edit this image to look like a medieval fantasy king, preserving facial
 
 ### Description
 
-Route chat completions to [MiniMax](https://platform.minimaxi.com)'s OpenAI-compatible API (`api.minimax.io/v1`) directly from Open WebUI. This pipe exposes MiniMax-M3 (512K context, the latest flagship model), MiniMax-M2.7, and MiniMax-M2.7-highspeed (both 204K context) as selectable models in your Open WebUI instance.
+Route chat completions to [MiniMax](https://platform.minimaxi.com)'s OpenAI-compatible API (`api.minimax.io/v1`) directly from Open WebUI. This pipe exposes MiniMax-M3 (1M context, with image and video input and adaptive or disabled thinking) and MiniMax-M2.7 (204,800-token context, always-on thinking) as selectable models in your Open WebUI instance.
 
 ### Configuration
 
@@ -952,6 +952,7 @@ Route chat completions to [MiniMax](https://platform.minimaxi.com)'s OpenAI-comp
 - `ENABLED_MODELS` (list): Which MiniMax models to expose (default: all)
 - `STRIP_THINKING` (bool): Strip `<think>…</think>` blocks from responses (default: `True`)
 - `DEFAULT_TEMPERATURE` (float): Default temperature when none is specified, 0.01–1.0 (default: `0.7`)
+- `THINKING_MODE` (str): Thinking mode for supporting models — `adaptive` (let the model decide) or `disabled`; ignored by always-on models (default: `adaptive`)
 
 **Prerequisites**: Get a MiniMax API key from [MiniMax Platform](https://platform.minimaxi.com).
 
@@ -959,13 +960,15 @@ Route chat completions to [MiniMax](https://platform.minimaxi.com)'s OpenAI-comp
 
 1. **Install the pipe**: Copy `functions/minimax_pipe.py` into Open WebUI via Workspace > Functions
 2. **Configure**: Set your `MINIMAX_API_KEY` in the pipe's Valves settings
-3. **Select model**: Choose "MiniMax M3", "MiniMax M2.7", or "MiniMax M2.7 Highspeed" from the model dropdown
+3. **Select model**: Choose "MiniMax M3" or "MiniMax M2.7" from the model dropdown
 4. **Start chatting**: The pipe streams responses directly from the MiniMax API
 
 ### Features
 
 - **OpenAI-Compatible Routing**: Uses MiniMax's `/v1/chat/completions` endpoint
-- **Three Models**: MiniMax-M3 (512K context flagship), MiniMax-M2.7 (full, 204K), and MiniMax-M2.7-highspeed (faster, 204K)
+- **Two Models**: MiniMax-M3 (1M-context flagship with image and video input) and MiniMax-M2.7 (204,800-token context)
+- **Multimodal Input**: Forwards inline image and video attachments to MiniMax-M3 as `image_url`/`video_url` content parts
+- **Thinking Controls**: Forwards `adaptive`/`disabled` thinking to MiniMax-M3; M2.7 stays always-on
 - **Streaming**: Real-time streamed responses via `chat:message:delta` events
 - **Temperature Clamping**: Automatically clamps temperature to MiniMax's accepted range (0.01–1.0)
 - **Think-Tag Stripping**: Strips `<think>…</think>` reasoning blocks from output (configurable)

--- a/functions/minimax_pipe.py
+++ b/functions/minimax_pipe.py
@@ -2,12 +2,13 @@
 title: MiniMax LLM Pipe
 author: octopus
 author_url: https://github.com/octo-patch
-version: 1.1.0
+version: 1.2.0
 required_open_webui_version: 0.6.0
 description: MiniMax LLM Pipe for Open WebUI — routes chat completions to MiniMax's
-OpenAI-compatible API (api.minimax.io/v1). Supports MiniMax-M3 (default),
-MiniMax-M2.7, and MiniMax-M2.7-highspeed models with streaming, temperature
-clamping, and automatic think-tag handling.
+OpenAI-compatible API (api.minimax.io/v1). Supports MiniMax-M3 (default) with
+image and video input plus adaptive/disabled thinking, and MiniMax-M2.7 with
+always-on thinking, with streaming, temperature clamping, and automatic
+think-tag handling.
 """
 
 import aiohttp
@@ -24,6 +25,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Tuple,
 )
 
 from fastapi import Request
@@ -41,19 +43,24 @@ MINIMAX_MODELS = [
     {
         "id": "MiniMax-M3",
         "name": "MiniMax M3",
-        "context_length": 524288,
+        "context_length": 1000000,
+        "input_modalities": ["text", "image", "video"],
+        "thinking": ["adaptive", "disabled"],
     },
     {
         "id": "MiniMax-M2.7",
         "name": "MiniMax M2.7",
-        "context_length": 204000,
-    },
-    {
-        "id": "MiniMax-M2.7-highspeed",
-        "name": "MiniMax M2.7 Highspeed",
-        "context_length": 204000,
+        "context_length": 204800,
+        "input_modalities": ["text"],
+        "thinking": ["always_on"],
     },
 ]
+
+# Thinking modes accepted by the chat-completions API. Each model declares
+# which of these it supports in MINIMAX_MODELS[*]["thinking"].
+THINKING_MODE_ADAPTIVE = "adaptive"
+THINKING_MODE_DISABLED = "disabled"
+THINKING_MODE_ALWAYS_ON = "always_on"
 
 # Temperature must be in (0.0, 1.0] for MiniMax
 MINIMAX_TEMP_MIN = 0.01
@@ -104,6 +111,14 @@ class Pipe:
         DEFAULT_TEMPERATURE: float = Field(
             default=0.7,
             description="Default temperature when none is specified (0.01–1.0)",
+        )
+        THINKING_MODE: str = Field(
+            default=THINKING_MODE_ADAPTIVE,
+            description=(
+                "Thinking mode for models that support it: "
+                "'adaptive' (let the model decide) or 'disabled'. "
+                "Ignored by always-on models."
+            ),
         )
 
     def __init__(self) -> None:
@@ -175,7 +190,9 @@ class Pipe:
             return error_msg
 
         # --- Build payload ---
-        messages = body.get("messages", [])
+        messages = self._normalize_messages(
+            body.get("messages", []), model_id
+        )
         temperature = _clamp_temperature(
             body.get("temperature", self.valves.DEFAULT_TEMPERATURE)
         )
@@ -192,6 +209,13 @@ class Pipe:
             payload["max_tokens"] = body["max_tokens"]
         if body.get("top_p") is not None:
             payload["top_p"] = body["top_p"]
+
+        # Forward adaptive/disabled thinking controls for models that support
+        # them. M3 accepts "adaptive" (let the model decide) and "disabled";
+        # M2.7 is always-on and ignores this field.
+        thinking_config = self._resolve_thinking(model_id, body)
+        if thinking_config is not None:
+            payload["thinking"] = thinking_config
 
         headers = {
             "Authorization": f"Bearer {self.valves.MINIMAX_API_KEY}",
@@ -253,6 +277,153 @@ class Pipe:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _message_content_to_str(content: Any) -> str:
+        """Flatten a message's content into a single string."""
+        if isinstance(content, str):
+            return content
+        parts: List[str] = []
+        if isinstance(content, list):
+            for item in content:
+                if isinstance(item, dict):
+                    if item.get("type") == "text" and isinstance(
+                        item.get("text"), str
+                    ):
+                        parts.append(item["text"])
+                    elif isinstance(item.get("content"), str):
+                        parts.append(item["content"])
+                elif isinstance(item, str):
+                    parts.append(item)
+        return "".join(parts)
+
+    def _model_supports_modality(
+        self, model_id: str, modality: str
+    ) -> bool:
+        """True when the resolved model lists the given input modality."""
+        for model in MINIMAX_MODELS:
+            if model["id"] == model_id:
+                return modality in model.get("input_modalities", ["text"])
+        return False
+
+    def _normalize_messages(
+        self, messages: List[Dict[str, Any]], model_id: str
+    ) -> List[Dict[str, Any]]:
+        """
+        Normalize Open WebUI messages for the MiniMax API.
+
+        For multimodal models (MiniMax-M3), inline attachments carried on the
+        Open WebUI message are converted to OpenAI-style multi-part content:
+        text plus image_url / video_url parts. For text-only models the content
+        is flattened to a string so the API never receives image or video
+        parts it cannot handle. The supplied ``model_id`` selects which path
+        applies.
+        """
+        normalized: List[Dict[str, Any]] = []
+        for message in messages:
+            role = message.get("role", "user")
+            content = message.get("content")
+            files = message.get("files")
+
+            # Already multi-part content from the caller
+            if isinstance(content, list):
+                normalized.append({"role": role, "content": content})
+                continue
+
+            text_content = (
+                content if isinstance(content, str) else self._message_content_to_str(content)
+            )
+
+            if files and self._model_supports_modality(
+                model_id, "image"
+            ):
+                parts: List[Dict[str, Any]] = []
+                if text_content:
+                    parts.append({"type": "text", "text": text_content})
+                for file in files:
+                    url = self._attachment_url(file)
+                    if not url:
+                        continue
+                    kind = file.get("type") or self._attachment_kind(url)
+                    if kind == "video" and self._model_supports_modality(
+                        model_id, "video"
+                    ):
+                        parts.append(
+                            {"type": "video_url", "video_url": {"url": url}}
+                        )
+                    else:
+                        parts.append(
+                            {"type": "image_url", "image_url": {"url": url}}
+                        )
+                normalized.append({"role": role, "content": parts or text_content})
+            else:
+                normalized.append({"role": role, "content": text_content})
+        return normalized
+
+    @staticmethod
+    def _attachment_url(file: Any) -> Optional[str]:
+        """Extract a URL or data URL from an Open WebUI file attachment."""
+        if not isinstance(file, dict):
+            return None
+        # Direct URL fields used by Open WebUI uploads
+        for key in ("url", "uri"):
+            value = file.get(key)
+            if isinstance(value, str) and value:
+                return value
+        # Nested { image_url: { url } } / { video_url: { url } }
+        for key in ("image_url", "video_url"):
+            nested = file.get(key)
+            if isinstance(nested, dict):
+                url = nested.get("url")
+                if isinstance(url, str) and url:
+                    return url
+        return None
+
+    @staticmethod
+    def _attachment_kind(url: str) -> str:
+        """Classify an attachment as 'image' or 'video' from its data URL."""
+        if url.startswith("data:"):
+            head = url.split(",", 1)[0]
+            if head.startswith("data:video"):
+                return "video"
+            return "image"
+        lower = url.lower().split("?", 1)[0]
+        if lower.endswith((".mp4", ".mov", ".webm", ".mkv", ".avi")):
+            return "video"
+        return "image"
+
+    def _resolve_thinking(
+        self, model_id: str, body: Dict[str, Any]
+    ) -> Optional[str]:
+        """
+        Resolve the thinking mode to forward to the API.
+
+        Only models that list adaptive/disabled thinking send the field; an
+        always-on model (e.g. M2.7) ignores it and returns None so the field
+        is omitted entirely.
+        """
+        supported: List[str] = []
+        for model in MINIMAX_MODELS:
+            if model["id"] == model_id:
+                supported = model.get("thinking", [])
+                break
+
+        if THINKING_MODE_ADAPTIVE not in supported and (
+            THINKING_MODE_DISABLED not in supported
+        ):
+            return None
+
+        requested = body.get("thinking", self.valves.THINKING_MODE)
+        if isinstance(requested, str) and requested in supported:
+            return requested
+        # Fall back to the valve default when it is supported, otherwise pick
+        # the first supported adaptive/disabled mode.
+        if self.valves.THINKING_MODE in supported:
+            return self.valves.THINKING_MODE
+        for mode in (THINKING_MODE_ADAPTIVE, THINKING_MODE_DISABLED):
+            if mode in supported:
+                return mode
+        return None
 
     def _resolve_model_id(self, pipe_id: str) -> Optional[str]:
         """Extract the MiniMax model ID from the pipe model string."""

--- a/tests/test_minimax_pipe.py
+++ b/tests/test_minimax_pipe.py
@@ -41,6 +41,9 @@ from minimax_pipe import (
     MINIMAX_API_BASE,
     MINIMAX_TEMP_MIN,
     MINIMAX_TEMP_MAX,
+    THINKING_MODE_ADAPTIVE,
+    THINKING_MODE_DISABLED,
+    THINKING_MODE_ALWAYS_ON,
 )
 
 
@@ -102,6 +105,7 @@ class TestPipeInit(unittest.TestCase):
         assert pipe.valves.MINIMAX_API_KEY == ""
         assert pipe.valves.STRIP_THINKING is True
         assert pipe.valves.DEFAULT_TEMPERATURE == 0.7
+        assert pipe.valves.THINKING_MODE == THINKING_MODE_ADAPTIVE
         assert len(pipe.valves.ENABLED_MODELS) == len(MINIMAX_MODELS)
 
     def test_pipes_returns_all_models(self):
@@ -119,6 +123,7 @@ class TestPipeInit(unittest.TestCase):
         result = pipe.pipes()
         assert len(result) == 1
         assert result[0]["id"] == "minimax-MiniMax-M2.7"
+        assert result[0]["name"] == "MiniMax MiniMax M2.7"
 
 
 class TestResolveModelId(unittest.TestCase):
@@ -131,13 +136,6 @@ class TestResolveModelId(unittest.TestCase):
     def test_m3_model(self):
         pipe = Pipe()
         assert pipe._resolve_model_id("minimax-MiniMax-M3") == "MiniMax-M3"
-
-    def test_highspeed_model(self):
-        pipe = Pipe()
-        assert (
-            pipe._resolve_model_id("minimax-MiniMax-M2.7-highspeed")
-            == "MiniMax-M2.7-highspeed"
-        )
 
     def test_with_function_prefix(self):
         pipe = Pipe()
@@ -290,26 +288,211 @@ class TestConstants(unittest.TestCase):
             assert "id" in model
             assert "name" in model
             assert "context_length" in model
+            assert "input_modalities" in model
+            assert "thinking" in model
 
     def test_model_ids(self):
         ids = [m["id"] for m in MINIMAX_MODELS]
         assert "MiniMax-M3" in ids
         assert "MiniMax-M2.7" in ids
-        assert "MiniMax-M2.7-highspeed" in ids
 
     def test_m3_is_first(self):
-        """M3 should be the first model (new default exposed)."""
+        """M3 should be the first model (default exposed)."""
         assert MINIMAX_MODELS[0]["id"] == "MiniMax-M3"
 
     def test_m3_context_length(self):
         m3 = next(m for m in MINIMAX_MODELS if m["id"] == "MiniMax-M3")
-        assert m3["context_length"] == 524288
+        assert m3["context_length"] == 1000000
+
+    def test_m27_context_length(self):
+        m27 = next(m for m in MINIMAX_MODELS if m["id"] == "MiniMax-M2.7")
+        assert m27["context_length"] == 204800
+
+    def test_m3_input_modalities(self):
+        m3 = next(m for m in MINIMAX_MODELS if m["id"] == "MiniMax-M3")
+        assert m3["input_modalities"] == ["text", "image", "video"]
+
+    def test_m27_text_only_modalities(self):
+        m27 = next(m for m in MINIMAX_MODELS if m["id"] == "MiniMax-M2.7")
+        assert m27["input_modalities"] == ["text"]
+
+    def test_m3_thinking_modes(self):
+        m3 = next(m for m in MINIMAX_MODELS if m["id"] == "MiniMax-M3")
+        assert m3["thinking"] == ["adaptive", "disabled"]
+
+    def test_m27_always_on_thinking(self):
+        m27 = next(m for m in MINIMAX_MODELS if m["id"] == "MiniMax-M2.7")
+        assert m27["thinking"] == ["always_on"]
+
+    def test_thinking_mode_constants(self):
+        assert THINKING_MODE_ADAPTIVE == "adaptive"
+        assert THINKING_MODE_DISABLED == "disabled"
+        assert THINKING_MODE_ALWAYS_ON == "always_on"
 
     def test_legacy_models_removed(self):
-        """Older versions (M2.5/M2.1/M2/M1) should not be present."""
+        """Older variants should not be present."""
         ids = [m["id"] for m in MINIMAX_MODELS]
-        for legacy in ("MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2", "MiniMax-M1"):
+        for legacy in (
+            "MiniMax-M2.7-highspeed",
+            "MiniMax-M2.5",
+            "MiniMax-M2.1",
+            "MiniMax-M2",
+            "MiniMax-M1",
+        ):
             assert legacy not in ids
+
+
+class TestNormalizeMessages(unittest.TestCase):
+    """Tests for Pipe._normalize_messages()."""
+
+    def _pipe(self):
+        pipe = Pipe()
+        pipe.valves.MINIMAX_API_KEY = "test-key"
+        return pipe
+
+    def test_string_content_unchanged(self):
+        pipe = self._pipe()
+        messages = [{"role": "user", "content": "Hello"}]
+        result = pipe._normalize_messages(messages, "MiniMax-M3")
+        assert result == [{"role": "user", "content": "Hello"}]
+
+    def test_text_only_model_flattens_files(self):
+        """M2.7 must not receive image parts even when files are present."""
+        pipe = self._pipe()
+        messages = [
+            {
+                "role": "user",
+                "content": "Describe this",
+                "files": [
+                    {"type": "image", "url": "data:image/png;base64,AAAA"}
+                ],
+            }
+        ]
+        result = pipe._normalize_messages(messages, "MiniMax-M2.7")
+        assert result == [
+            {"role": "user", "content": "Describe this"}
+        ]
+
+    def test_multimodal_model_inlines_image_file(self):
+        pipe = self._pipe()
+        messages = [
+            {
+                "role": "user",
+                "content": "Describe this",
+                "files": [
+                    {"type": "image", "url": "data:image/png;base64,AAAA"}
+                ],
+            }
+        ]
+        result = pipe._normalize_messages(messages, "MiniMax-M3")
+        assert len(result) == 1
+        content = result[0]["content"]
+        assert isinstance(content, list)
+        assert {"type": "text", "text": "Describe this"} in content
+        assert any(p.get("type") == "image_url" for p in content)
+
+    def test_multimodal_model_inlines_video_file(self):
+        pipe = self._pipe()
+        messages = [
+            {
+                "role": "user",
+                "content": "Describe this clip",
+                "files": [
+                    {"type": "video", "url": "data:video/mp4;base64,AAAA"}
+                ],
+            }
+        ]
+        result = pipe._normalize_messages(messages, "MiniMax-M3")
+        content = result[0]["content"]
+        assert isinstance(content, list)
+        assert any(p.get("type") == "video_url" for p in content)
+
+    def test_already_multipart_content_passthrough(self):
+        pipe = self._pipe()
+        parts = [{"type": "text", "text": "Hi"}]
+        messages = [{"role": "user", "content": parts}]
+        result = pipe._normalize_messages(messages, "MiniMax-M3")
+        assert result[0]["content"] is parts
+
+    def test_image_url_extension_detected_as_video(self):
+        pipe = self._pipe()
+        messages = [
+            {
+                "role": "user",
+                "content": "",
+                "files": [{"url": "https://example.com/clip.mp4"}],
+            }
+        ]
+        result = pipe._normalize_messages(messages, "MiniMax-M3")
+        content = result[0]["content"]
+        assert any(p.get("type") == "video_url" for p in content)
+
+
+class TestResolveThinking(unittest.TestCase):
+    """Tests for Pipe._resolve_thinking()."""
+
+    def _pipe(self):
+        pipe = Pipe()
+        pipe.valves.MINIMAX_API_KEY = "test-key"
+        return pipe
+
+    def test_always_on_model_returns_none(self):
+        """M2.7 is always-on, so the thinking field must be omitted."""
+        pipe = self._pipe()
+        assert pipe._resolve_thinking("MiniMax-M2.7", {}) is None
+
+    def test_m3_default_adaptive(self):
+        pipe = self._pipe()
+        assert pipe._resolve_thinking("MiniMax-M3", {}) == "adaptive"
+
+    def test_m3_body_override_disabled(self):
+        pipe = self._pipe()
+        assert pipe._resolve_thinking("MiniMax-M3", {"thinking": "disabled"}) == "disabled"
+
+    def test_m3_ignores_unsupported_body_value(self):
+        pipe = self._pipe()
+        assert pipe._resolve_thinking("MiniMax-M3", {"thinking": "bogus"}) == "adaptive"
+
+    def test_m3_respects_valve_default(self):
+        pipe = self._pipe()
+        pipe.valves.THINKING_MODE = "disabled"
+        assert pipe._resolve_thinking("MiniMax-M3", {}) == "disabled"
+
+    def test_unknown_model_returns_none(self):
+        pipe = self._pipe()
+        assert pipe._resolve_thinking("MiniMax-Unknown", {}) is None
+
+
+class TestPayloadThinking(unittest.TestCase):
+    """Verify the thinking field is added to the payload only when supported."""
+
+    def test_m3_payload_includes_thinking(self):
+        pipe = Pipe()
+        pipe.valves.MINIMAX_API_KEY = "test-key"
+        body = {
+            "model": "minimax-MiniMax-M3",
+            "messages": [{"role": "user", "content": "Hi"}],
+        }
+        model_id = pipe._resolve_model_id(body["model"])
+        thinking = pipe._resolve_thinking(model_id, body)
+        payload = {"model": model_id, "messages": body["messages"], "stream": True}
+        if thinking is not None:
+            payload["thinking"] = thinking
+        assert payload["thinking"] == "adaptive"
+
+    def test_m27_payload_omits_thinking(self):
+        pipe = Pipe()
+        pipe.valves.MINIMAX_API_KEY = "test-key"
+        body = {
+            "model": "minimax-MiniMax-M2.7",
+            "messages": [{"role": "user", "content": "Hi"}],
+        }
+        model_id = pipe._resolve_model_id(body["model"])
+        thinking = pipe._resolve_thinking(model_id, body)
+        payload = {"model": model_id, "messages": body["messages"], "stream": True}
+        if thinking is not None:
+            payload["thinking"] = thinking
+        assert "thinking" not in payload
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reason: Refresh MiniMax model parameters — correct M3/M2.7 context windows and forward image/video input plus adaptive/disabled thinking.

## Changes
- Correct context windows to the provider's current parameters: MiniMax-M3 = 1,000,000 tokens (was 524,288) and MiniMax-M2.7 = 204,800 tokens (was 204,000).
- Record per-model input modalities and thinking modes on each model entry (M3: text/image/video with adaptive|disabled thinking; M2.7: text-only, always-on thinking).
- Add a `THINKING_MODE` valve (adaptive by default) and forward the `thinking` field for models that support it; always-on models omit the field.
- Normalize Open WebUI messages: inline `files` attachments as OpenAI-style `image_url`/`video_url` content parts for multimodal models, and flatten content to a string for text-only models so they never receive unsupported parts.
- Remove the retired `MiniMax-M2.7-highspeed` variant from the model list.
- Bump pipe metadata version to 1.2.0 and update the README MiniMax section.

## Checks
- `python3 -m pytest tests/test_minimax_pipe.py` — 55 passed.
- `python3 -m py_compile functions/minimax_pipe.py tests/test_minimax_pipe.py` — clean.
