### PR TITLE
Add zero-key OutageDeck provider status tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repository contains **20+ specialized tools and functions** designed to enh
 - **Pexels Media Search** - High-quality photos and videos from Pexels API
 - **YouTube Search & Embed** - Search YouTube and play videos in embedded player
 - **Xquik X Data Tool** - Search and look up X posts, users, timelines, and trends
+- **OutageDeck Provider Status** - Check provider health and incident timelines without an API key
 - **Native Image Generator** - Direct Open WebUI image generation with Ollama model management
 - **Hugging Face Image Generator** - AI-powered image creation
 - **ComfyUI Image-to-Image (Qwen Edit 2509)** - Advanced image editing with multi-image support
@@ -113,29 +114,30 @@ Most tools are designed to work with minimal configuration. Key configuration ar
 12. [ComfyUI Text-to-Video Tool](#comfyui-text-to-video-tool)
 13. [OpenWeatherMap Forecast Tool](#openweathermap-forecast-tool)
 14. [Xquik X Data Tool](#xquik-x-data-tool)
-15. [Flux Kontext ComfyUI Pipe](#flux-kontext-comfyui-pipe)
-16. [Google Veo Text-to-Video & Image-to-Video Pipe](#google-veo-text-to-video--image-to-video-pipe)
-17. [MiniMax LLM Pipe](#minimax-llm-pipe)
-18. [Planner Agent v3](#planner-agent-v3)
-19. [arXiv Research MCTS Pipe](#arxiv-research-mcts-pipe)
-20. [Multi Model Conversations v2 Pipe](#multi-model-conversations-v2-pipe)
-21. [Resume Analyzer Pipe](#resume-analyzer-pipe)
-22. [Mopidy Music Controller](#mopidy-music-controller)
-23. [Letta Agent Pipe](#letta-agent-pipe)
-24. [Perplexica Pipe](#perplexica-pipe)
-25. [OpenRouter Image Pipe](#openrouter-image-pipe)
-26. [OpenRouter WebSearch Citations Filter](#openrouter-websearch-citations-filter)
-27. [Doodle Paint Filter](#doodle-paint-filter)
-28. [Prompt Enhancer Filter](#prompt-enhancer-filter)
-29. [Semantic Router Filter](#semantic-router-filter)
-30. [Full Document Filter](#full-document-filter)
-31. [Clean Thinking Tags Filter](#clean-thinking-tags-filter)
-32. [Using the Provided ComfyUI Workflows](#using-the-provided-comfyui-workflows)
-33. [Installation](#installation)
-34. [Contributing](#contributing)
-35. [License](#license)
-36. [Credits](#credits)
-37. [Support](#support)
+15. [OutageDeck Provider Status](#outagedeck-provider-status)
+16. [Flux Kontext ComfyUI Pipe](#flux-kontext-comfyui-pipe)
+17. [Google Veo Text-to-Video & Image-to-Video Pipe](#google-veo-text-to-video--image-to-video-pipe)
+18. [MiniMax LLM Pipe](#minimax-llm-pipe)
+19. [Planner Agent v3](#planner-agent-v3)
+20. [arXiv Research MCTS Pipe](#arxiv-research-mcts-pipe)
+21. [Multi Model Conversations v2 Pipe](#multi-model-conversations-v2-pipe)
+22. [Resume Analyzer Pipe](#resume-analyzer-pipe)
+23. [Mopidy Music Controller](#mopidy-music-controller)
+24. [Letta Agent Pipe](#letta-agent-pipe)
+25. [Perplexica Pipe](#perplexica-pipe)
+26. [OpenRouter Image Pipe](#openrouter-image-pipe)
+27. [OpenRouter WebSearch Citations Filter](#openrouter-websearch-citations-filter)
+28. [Doodle Paint Filter](#doodle-paint-filter)
+29. [Prompt Enhancer Filter](#prompt-enhancer-filter)
+30. [Semantic Router Filter](#semantic-router-filter)
+31. [Full Document Filter](#full-document-filter)
+32. [Clean Thinking Tags Filter](#clean-thinking-tags-filter)
+33. [Using the Provided ComfyUI Workflows](#using-the-provided-comfyui-workflows)
+34. [Installation](#installation)
+35. [Contributing](#contributing)
+36. [License](#license)
+37. [Credits](#credits)
+38. [Support](#support)
 ---
 
 ## 🧪 Tools
@@ -859,6 +861,52 @@ Search and look up X posts, users, timelines, and trends through the Xquik API. 
 - **User Timelines**: Lists recent user posts with optional replies and parent posts
 - **Trends**: Fetches regional X trends by WOEID
 - **Structured Output**: Returns JSON responses for reliable model analysis
+
+---
+
+### OutageDeck Provider Status
+
+### Description
+
+Check current provider and service health, find active incidents, and inspect incident update timelines through the public [OutageDeck API](https://outagedeck.com/developers/api?utm_source=open_webui&utm_medium=integration&utm_campaign=open_webui_tool). The tool is read-only, requires no API key, and includes source freshness in provider responses so models can qualify what they report.
+
+### Configuration
+
+- `REQUEST_TIMEOUT_SECONDS` (int): Request timeout from 5 to 60 seconds (default: 15)
+- `MAX_PROVIDER_RESULTS` (int): Maximum providers returned by one search (default: 20)
+- `MAX_TIMELINE_UPDATES` (int): Maximum updates returned for one incident (default: 20)
+
+**Prerequisites**: None. Public status lookups work without an OutageDeck account or API key.
+
+### Usage
+
+- **Check a Provider:**
+
+  ```python
+  Is GitHub having an outage? Check its services and source freshness.
+  ```
+
+- **Find Active Incidents:**
+
+  ```python
+  List active major incidents across the providers OutageDeck monitors.
+  ```
+
+- **Inspect a Timeline:**
+
+  ```python
+  Get the update timeline for this OutageDeck incident slug.
+  ```
+
+### Features
+
+- **Zero-Key Setup**: Uses OutageDeck's public read-only API without credentials
+- **Provider Discovery**: Searches monitored vendors by name, health, or category
+- **Component Status**: Checks individual services such as GitHub Actions
+- **Incident Triage**: Filters active or resolved incidents by provider and severity
+- **Update Timelines**: Returns bounded incident histories for root-cause context
+- **Safe Requests**: Uses a fixed HTTPS origin, strict slug validation, timeouts, and no redirects
+- **Bounded Output**: Selects the operational fields models need instead of returning oversized payloads
 
 ---
 

--- a/tests/test_outagedeck_status_tool.py
+++ b/tests/test_outagedeck_status_tool.py
@@ -1,0 +1,282 @@
+"""Focused tests for the zero-key OutageDeck Open WebUI tool."""
+
+import asyncio
+import importlib.util
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import aiohttp
+import pytest
+
+
+MODULE_PATH = Path(__file__).parents[1] / "tools" / "outagedeck_status_tool.py"
+SPEC = importlib.util.spec_from_file_location("outagedeck_status_tool", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class FakeResponse:
+    """Async response context manager used by the fake aiohttp session."""
+
+    def __init__(self, status=200, payload=None, text=""):
+        self.status = status
+        self.payload = payload if payload is not None else {}
+        self.response_text = text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    async def json(self, content_type=None):
+        return self.payload
+
+    async def text(self):
+        return self.response_text
+
+
+class FakeSession:
+    """Capture request arguments and return a configured fake response."""
+
+    def __init__(self, response, calls, timeout=None):
+        self.response = response
+        self.calls = calls
+        self.timeout = timeout
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    def get(self, url, **kwargs):
+        self.calls.append({"url": url, **kwargs, "timeout": self.timeout})
+        return self.response
+
+
+def session_factory(response, calls):
+    """Build a ClientSession-compatible factory for one response."""
+
+    def factory(timeout=None):
+        return FakeSession(response, calls, timeout=timeout)
+
+    return factory
+
+
+def parsed_json(result):
+    """Extract the fenced JSON object from a formatted tool response."""
+    return json.loads(result.split("```json\n", 1)[1].split("\n```", 1)[0])
+
+
+@pytest.mark.asyncio
+async def test_get_provider_status_uses_fixed_origin_and_campaign_params():
+    calls = []
+    response = FakeResponse(
+        payload={
+            "data": {
+                "slug": "github",
+                "name": "GitHub",
+                "currentStatus": {"code": "operational"},
+                "services": [{"slug": "github-actions", "status": "operational"}],
+                "activeIncidents": [],
+            }
+        }
+    )
+    tool = MODULE.Tools()
+
+    with patch.object(
+        MODULE.aiohttp,
+        "ClientSession",
+        session_factory(response, calls),
+    ):
+        result = await tool.get_provider_status("github")
+
+    assert len(calls) == 1
+    assert calls[0]["url"] == "https://outagedeck.com/api/v1/providers/github"
+    assert calls[0]["allow_redirects"] is False
+    assert calls[0]["params"] == MODULE.CAMPAIGN_PARAMS
+    assert calls[0]["headers"]["accept"] == "application/json"
+    assert calls[0]["timeout"].total == 15
+    assert parsed_json(result)["status"]["code"] == "operational"
+    assert "utm_source=open_webui" in result
+
+
+@pytest.mark.asyncio
+async def test_find_providers_validates_filters_and_bounds_output():
+    calls = []
+    providers = [
+        {
+            "slug": f"provider-{index}",
+            "name": f"Provider {index}",
+            "currentStatus": {"code": "operational"},
+        }
+        for index in range(3)
+    ]
+    response = FakeResponse(payload={"data": {"count": 3, "providers": providers}})
+    tool = MODULE.Tools()
+    tool.valves.MAX_PROVIDER_RESULTS = 2
+
+    with patch.object(
+        MODULE.aiohttp,
+        "ClientSession",
+        session_factory(response, calls),
+    ):
+        result = await tool.find_providers(
+            query="provider", status="operational", category="cloud", sort="name"
+        )
+
+    assert calls[0]["params"] == {
+        "q": "provider",
+        "status": "operational",
+        "category": "cloud",
+        "sort": "name",
+        **MODULE.CAMPAIGN_PARAMS,
+    }
+    output = parsed_json(result)
+    assert output["count"] == 2
+    assert output["totalMatches"] == 3
+
+    with pytest.raises(ValueError, match="status must be one of"):
+        await tool.find_providers(status="offline")
+
+
+@pytest.mark.asyncio
+async def test_list_incidents_sends_exact_filters_and_normalizes_results():
+    calls = []
+    response = FakeResponse(
+        payload={
+            "data": {
+                "count": 1,
+                "page": 2,
+                "totalPages": 3,
+                "totalIncidents": 5,
+                "incidents": [
+                    {
+                        "slug": "github-api-errors",
+                        "title": "API errors",
+                        "status": "investigating",
+                        "severity": "major",
+                    }
+                ],
+            }
+        }
+    )
+    tool = MODULE.Tools()
+
+    with patch.object(
+        MODULE.aiohttp,
+        "ClientSession",
+        session_factory(response, calls),
+    ):
+        result = await tool.list_incidents(
+            provider_slug="github",
+            state="resolved",
+            severity="major",
+            page=2,
+            limit=5,
+        )
+
+    assert calls[0]["params"] == {
+        "provider": "github",
+        "state": "resolved",
+        "severity": "major",
+        "page": 2,
+        "limit": 5,
+        **MODULE.CAMPAIGN_PARAMS,
+    }
+    output = parsed_json(result)
+    assert output["incidents"][0]["slug"] == "github-api-errors"
+    assert output["totalIncidents"] == 5
+
+
+@pytest.mark.asyncio
+async def test_incident_details_caps_timeline_to_latest_updates():
+    calls = []
+    response = FakeResponse(
+        payload={
+            "data": {
+                "slug": "github-api-errors",
+                "title": "API errors",
+                "updates": [
+                    {"status": "investigating", "body": "one", "createdAt": "1"},
+                    {"status": "monitoring", "body": "two", "createdAt": "2"},
+                    {"status": "resolved", "body": "three", "createdAt": "3"},
+                ],
+            }
+        }
+    )
+    tool = MODULE.Tools()
+    tool.valves.MAX_TIMELINE_UPDATES = 2
+
+    with patch.object(
+        MODULE.aiohttp,
+        "ClientSession",
+        session_factory(response, calls),
+    ):
+        result = await tool.get_incident_details("github-api-errors")
+
+    updates = parsed_json(result)["updates"]
+    assert [update["body"] for update in updates] == ["two", "three"]
+
+
+@pytest.mark.asyncio
+async def test_service_status_rejects_unsafe_slug_without_network_access():
+    tool = MODULE.Tools()
+    with patch.object(MODULE.aiohttp, "ClientSession") as client_session:
+        with pytest.raises(ValueError, match="service_slug"):
+            await tool.get_service_status("https://example.com/steal")
+    client_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_http_errors_are_model_readable():
+    calls = []
+    response = FakeResponse(status=404, payload={"error": "not found"})
+    tool = MODULE.Tools()
+
+    with patch.object(
+        MODULE.aiohttp,
+        "ClientSession",
+        session_factory(response, calls),
+    ):
+        result = await tool.get_provider_status("missing-provider")
+
+    assert "failed (404)" in result
+    assert "not found" in result
+
+
+@pytest.mark.asyncio
+async def test_network_errors_are_model_readable():
+    tool = MODULE.Tools()
+
+    class BrokenSession:
+        async def __aenter__(self):
+            raise aiohttp.ClientConnectionError("offline")
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+    with patch.object(MODULE.aiohttp, "ClientSession", return_value=BrokenSession()):
+        result = await tool.get_provider_status("github")
+
+    assert "failed (network)" in result
+    assert "Could not reach OutageDeck" in result
+
+
+@pytest.mark.asyncio
+async def test_status_emitter_finishes_on_timeout():
+    events = []
+    tool = MODULE.Tools()
+
+    async def emitter(event):
+        events.append(event)
+
+    with patch.object(tool, "_get_json", side_effect=asyncio.TimeoutError):
+        with pytest.raises(asyncio.TimeoutError):
+            await tool.get_provider_status("github", __event_emitter__=emitter)
+
+    assert events[0]["data"]["done"] is False
+    assert events[-1]["data"]["done"] is True

--- a/tools/outagedeck_status_tool.py
+++ b/tools/outagedeck_status_tool.py
@@ -1,0 +1,487 @@
+"""
+title: OutageDeck Provider Status
+description: Check provider and service health, active incidents, and incident timelines without an API key
+author: OutageDeck
+author_url: https://outagedeck.com
+funding_url: https://outagedeck.com/pricing?utm_source=open_webui&utm_medium=integration&utm_campaign=open_webui_tool
+requirements:aiohttp
+version: 0.1.0
+license: MIT
+"""
+
+import asyncio
+import json
+import re
+from typing import Any, Awaitable, Callable, Dict, Optional
+from urllib.parse import urlencode
+
+import aiohttp
+from pydantic import BaseModel, Field
+
+
+BASE_URL = "https://outagedeck.com/api/v1"
+CAMPAIGN_PARAMS = {
+    "utm_source": "open_webui",
+    "utm_medium": "integration",
+    "utm_campaign": "open_webui_tool",
+}
+SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+PROVIDER_STATUSES = {
+    "operational",
+    "degraded",
+    "partial_outage",
+    "major_outage",
+    "maintenance",
+    "unknown",
+}
+PROVIDER_CATEGORIES = {
+    "cloud",
+    "hosting",
+    "ai",
+    "devtools",
+    "data",
+    "monitoring",
+    "auth",
+    "security",
+    "email",
+    "comms",
+    "telecom",
+    "productivity",
+    "fintech",
+}
+INCIDENT_STATES = {"active", "resolved"}
+INCIDENT_SEVERITIES = {"minor", "major", "critical", "maintenance"}
+PROVIDER_SORTS = {"severity", "name"}
+
+
+async def emit_status(
+    event_emitter: Optional[Callable[[Any], Awaitable[None]]],
+    description: str,
+    done: bool = False,
+) -> None:
+    """Emit an Open WebUI status event when an emitter is available."""
+    if event_emitter:
+        await event_emitter(
+            {"type": "status", "data": {"description": description, "done": done}}
+        )
+
+
+def validate_slug(value: str, label: str, required: bool = True) -> str:
+    """Return a safe OutageDeck slug or raise a model-readable validation error."""
+    slug = (value or "").strip()
+    if not slug and not required:
+        return ""
+    if not slug or not SLUG_PATTERN.fullmatch(slug):
+        raise ValueError(
+            f"{label} must contain lowercase letters, numbers, and single hyphens only"
+        )
+    return slug
+
+
+def validate_choice(value: str, label: str, choices: set) -> str:
+    """Validate an optional enum-like tool argument."""
+    choice = (value or "").strip()
+    if choice and choice not in choices:
+        allowed = ", ".join(sorted(choices))
+        raise ValueError(f"{label} must be one of: {allowed}")
+    return choice
+
+
+def validate_integer(value: int, label: str, minimum: int, maximum: int) -> int:
+    """Validate a bounded integer without accepting booleans as integers."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{label} must be an integer")
+    if value < minimum or value > maximum:
+        raise ValueError(f"{label} must be between {minimum} and {maximum}")
+    return value
+
+
+def trim_text(value: Any, maximum: int = 500) -> Any:
+    """Bound long text fields while leaving non-string values unchanged."""
+    if isinstance(value, str) and len(value) > maximum:
+        return value[: maximum - 1].rstrip() + "…"
+    return value
+
+
+def incident_summary(incident: Dict[str, Any]) -> Dict[str, Any]:
+    """Select the incident fields most useful to an LLM during triage."""
+    return {
+        "slug": incident.get("slug"),
+        "title": incident.get("title"),
+        "summary": trim_text(incident.get("summary")),
+        "status": incident.get("status"),
+        "severity": incident.get("severity"),
+        "startedAt": incident.get("startedAt"),
+        "updatedAt": incident.get("updatedAt"),
+        "resolvedAt": incident.get("resolvedAt"),
+        "provider": incident.get("provider"),
+        "affectedServices": (incident.get("affectedServices") or [])[:20],
+    }
+
+
+def provider_summary(provider: Dict[str, Any]) -> Dict[str, Any]:
+    """Select bounded provider health, source, service, and incident fields."""
+    source = provider.get("source") or {}
+    current_status = provider.get("currentStatus") or {}
+    return {
+        "slug": provider.get("slug"),
+        "name": provider.get("name"),
+        "status": {
+            "code": current_status.get("code"),
+            "label": current_status.get("label"),
+            "headline": current_status.get("headline"),
+            "summary": trim_text(current_status.get("summary")),
+            "capturedAt": current_status.get("capturedAt"),
+        },
+        "categories": (provider.get("categories") or [])[:20],
+        "counts": provider.get("counts"),
+        "source": {
+            "name": source.get("name"),
+            "checkedAt": source.get("checkedAt"),
+            "officialUrl": source.get("officialUrl"),
+        },
+        "services": [
+            {
+                "slug": service.get("slug"),
+                "name": service.get("name"),
+                "status": service.get("status"),
+                "category": service.get("category"),
+            }
+            for service in (provider.get("services") or [])[:30]
+        ],
+        "activeIncidents": [
+            incident_summary(incident)
+            for incident in (provider.get("activeIncidents") or [])[:20]
+        ],
+    }
+
+
+def campaign_url(path: str) -> str:
+    """Create an attributable human-readable OutageDeck source URL."""
+    return f"https://outagedeck.com{path}?{urlencode(CAMPAIGN_PARAMS)}"
+
+
+class Tools:
+    """Read-only Open WebUI tools for OutageDeck provider and incident status."""
+
+    class Valves(BaseModel):
+        """Administrator-controlled request and response bounds."""
+
+        REQUEST_TIMEOUT_SECONDS: int = Field(
+            default=15,
+            ge=5,
+            le=60,
+            description="OutageDeck request timeout in seconds",
+        )
+        MAX_PROVIDER_RESULTS: int = Field(
+            default=20,
+            ge=1,
+            le=50,
+            description="Maximum providers returned by one search",
+        )
+        MAX_TIMELINE_UPDATES: int = Field(
+            default=20,
+            ge=1,
+            le=50,
+            description="Maximum updates returned for one incident",
+        )
+
+    def __init__(self) -> None:
+        """Initialize default Open WebUI valve values."""
+        self.valves = self.Valves()
+        self.citation = False
+
+    async def _get_json(
+        self, path: str, params: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Fetch one fixed-origin API path and normalize transport failures."""
+        clean_params = {
+            key: value
+            for key, value in (params or {}).items()
+            if value is not None and value != ""
+        }
+        clean_params.update(CAMPAIGN_PARAMS)
+        timeout = aiohttp.ClientTimeout(total=self.valves.REQUEST_TIMEOUT_SECONDS)
+        headers = {
+            "accept": "application/json",
+            "user-agent": "OutageDeck-OpenWebUI-Tool/0.1.0",
+        }
+
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(
+                    f"{BASE_URL}{path}",
+                    headers=headers,
+                    params=clean_params,
+                    allow_redirects=False,
+                ) as response:
+                    try:
+                        payload = await response.json(content_type=None)
+                    except (json.JSONDecodeError, ValueError, aiohttp.ContentTypeError):
+                        payload = {"message": trim_text(await response.text())}
+
+                    if response.status < 200 or response.status >= 300:
+                        return {
+                            "ok": False,
+                            "status": response.status,
+                            "error": payload,
+                        }
+                    if not isinstance(payload, dict):
+                        return {
+                            "ok": False,
+                            "status": response.status,
+                            "error": {
+                                "message": "OutageDeck returned an invalid response"
+                            },
+                        }
+                    return {"ok": True, "status": response.status, "data": payload}
+        except asyncio.TimeoutError:
+            return {
+                "ok": False,
+                "status": 0,
+                "error": {"message": "The OutageDeck request timed out"},
+            }
+        except aiohttp.ClientError as exc:
+            return {
+                "ok": False,
+                "status": 0,
+                "error": {"message": f"Could not reach OutageDeck: {exc}"},
+            }
+
+    def _format_result(
+        self,
+        title: str,
+        payload: Dict[str, Any],
+        normalized: Any,
+        source_url: str,
+    ) -> str:
+        """Format a bounded result and its attributable human-facing source."""
+        if not payload["ok"]:
+            status = payload.get("status") or "network"
+            error = json.dumps(payload.get("error"), ensure_ascii=False)
+            return f"{title} failed ({status}): {error}"
+        return (
+            f"{title}\n\n"
+            f"```json\n{json.dumps(normalized, indent=2, ensure_ascii=False)}\n```\n\n"
+            f"Source: {source_url}"
+        )
+
+    async def find_providers(
+        self,
+        query: str = "",
+        status: str = "",
+        category: str = "",
+        sort: str = "severity",
+        __event_emitter__: Optional[Callable[[Any], Awaitable[None]]] = None,
+    ) -> str:
+        """
+        Find monitored vendors and see their current status.
+
+        Args:
+            query: Provider name or keyword, up to 100 characters.
+            status: Optional operational, degraded, partial_outage, major_outage,
+                maintenance, or unknown filter.
+            category: Optional cloud, hosting, ai, devtools, data, monitoring,
+                auth, security, email, comms, telecom, productivity, or fintech.
+            sort: Sort providers by severity or name.
+        """
+        clean_query = (query or "").strip()
+        if len(clean_query) > 100:
+            raise ValueError("query must be 100 characters or fewer")
+        clean_status = validate_choice(status, "status", PROVIDER_STATUSES)
+        clean_category = validate_choice(category, "category", PROVIDER_CATEGORIES)
+        clean_sort = validate_choice(sort, "sort", PROVIDER_SORTS) or "severity"
+
+        await emit_status(__event_emitter__, "Checking monitored providers")
+        try:
+            payload = await self._get_json(
+                "/providers",
+                {
+                    "q": clean_query,
+                    "status": clean_status,
+                    "category": clean_category,
+                    "sort": clean_sort,
+                },
+            )
+            data = payload.get("data", {}).get("data", {}) if payload["ok"] else {}
+            providers = (data.get("providers") or [])[
+                : self.valves.MAX_PROVIDER_RESULTS
+            ]
+            normalized = {
+                "count": len(providers),
+                "totalMatches": data.get("count", len(providers)),
+                "providers": [provider_summary(item) for item in providers],
+            }
+            source_path = "/providers"
+            return self._format_result(
+                "OutageDeck provider search",
+                payload,
+                normalized,
+                campaign_url(source_path),
+            )
+        finally:
+            await emit_status(__event_emitter__, "Provider check finished", done=True)
+
+    async def get_provider_status(
+        self,
+        provider_slug: str,
+        __event_emitter__: Optional[Callable[[Any], Awaitable[None]]] = None,
+    ) -> str:
+        """
+        Get one provider's status, freshness, services, and active incidents.
+
+        Args:
+            provider_slug: Lowercase OutageDeck provider slug, such as github,
+                openai, anthropic, aws, or cloudflare.
+        """
+        slug = validate_slug(provider_slug, "provider_slug")
+        await emit_status(__event_emitter__, f"Checking provider: {slug}")
+        try:
+            payload = await self._get_json(f"/providers/{slug}")
+            data = payload.get("data", {}).get("data", {}) if payload["ok"] else {}
+            normalized = provider_summary(data) if data else {}
+            return self._format_result(
+                f"OutageDeck provider status: {slug}",
+                payload,
+                normalized,
+                campaign_url(f"/providers/{slug}"),
+            )
+        finally:
+            await emit_status(__event_emitter__, "Provider status finished", done=True)
+
+    async def list_incidents(
+        self,
+        provider_slug: str = "",
+        state: str = "active",
+        severity: str = "",
+        page: int = 1,
+        limit: int = 10,
+        __event_emitter__: Optional[Callable[[Any], Awaitable[None]]] = None,
+    ) -> str:
+        """
+        List active or resolved incidents, optionally filtered by provider.
+
+        Args:
+            provider_slug: Optional lowercase provider slug, such as github.
+            state: Optional active or resolved filter. Defaults to active.
+            severity: Optional minor, major, critical, or maintenance filter.
+            page: Results page, starting at 1.
+            limit: Incidents per page, from 1 to 50.
+        """
+        slug = validate_slug(provider_slug, "provider_slug", required=False)
+        clean_state = validate_choice(state, "state", INCIDENT_STATES)
+        clean_severity = validate_choice(severity, "severity", INCIDENT_SEVERITIES)
+        clean_page = validate_integer(page, "page", 1, 10000)
+        clean_limit = validate_integer(limit, "limit", 1, 50)
+
+        target = slug or "all providers"
+        await emit_status(__event_emitter__, f"Checking incidents for {target}")
+        try:
+            payload = await self._get_json(
+                "/incidents",
+                {
+                    "provider": slug,
+                    "state": clean_state,
+                    "severity": clean_severity,
+                    "page": clean_page,
+                    "limit": clean_limit,
+                },
+            )
+            data = payload.get("data", {}).get("data", {}) if payload["ok"] else {}
+            normalized = {
+                "count": data.get("count", 0),
+                "page": data.get("page", clean_page),
+                "totalPages": data.get("totalPages"),
+                "totalIncidents": data.get("totalIncidents"),
+                "incidents": [
+                    incident_summary(item) for item in (data.get("incidents") or [])
+                ],
+            }
+            source_path = f"/providers/{slug}/incidents" if slug else "/incidents"
+            return self._format_result(
+                f"OutageDeck incidents: {target}",
+                payload,
+                normalized,
+                campaign_url(source_path),
+            )
+        finally:
+            await emit_status(__event_emitter__, "Incident check finished", done=True)
+
+    async def get_incident_details(
+        self,
+        incident_slug: str,
+        __event_emitter__: Optional[Callable[[Any], Awaitable[None]]] = None,
+    ) -> str:
+        """
+        Get an incident's status, affected services, and update timeline.
+
+        Args:
+            incident_slug: Lowercase incident slug returned by list_incidents or a
+                provider status lookup.
+        """
+        slug = validate_slug(incident_slug, "incident_slug")
+        await emit_status(__event_emitter__, f"Checking incident: {slug}")
+        try:
+            payload = await self._get_json(f"/incidents/{slug}")
+            data = payload.get("data", {}).get("data", {}) if payload["ok"] else {}
+            normalized = incident_summary(data) if data else {}
+            if data:
+                normalized["impactSummary"] = trim_text(data.get("impactSummary"))
+                normalized["updates"] = [
+                    {
+                        "status": update.get("status"),
+                        "body": trim_text(update.get("body"), 1000),
+                        "createdAt": update.get("createdAt"),
+                    }
+                    for update in (data.get("updates") or [])[
+                        -self.valves.MAX_TIMELINE_UPDATES :
+                    ]
+                ]
+            return self._format_result(
+                f"OutageDeck incident: {slug}",
+                payload,
+                normalized,
+                campaign_url(f"/incidents/{slug}"),
+            )
+        finally:
+            await emit_status(__event_emitter__, "Incident details finished", done=True)
+
+    async def get_service_status(
+        self,
+        service_slug: str,
+        __event_emitter__: Optional[Callable[[Any], Awaitable[None]]] = None,
+    ) -> str:
+        """
+        Get component-level status and incident history for one service.
+
+        Args:
+            service_slug: Lowercase service slug returned in provider status,
+                such as github-actions, openai-api, or cloudflare-workers.
+        """
+        slug = validate_slug(service_slug, "service_slug")
+        await emit_status(__event_emitter__, f"Checking service: {slug}")
+        try:
+            payload = await self._get_json(f"/services/{slug}")
+            data = payload.get("data", {}).get("data", {}) if payload["ok"] else {}
+            normalized = {
+                "slug": data.get("slug"),
+                "name": data.get("name"),
+                "status": data.get("status"),
+                "summary": trim_text(data.get("summary")),
+                "description": trim_text(data.get("description")),
+                "category": data.get("category"),
+                "provider": data.get("provider"),
+                "counts": data.get("counts"),
+                "incidents": [
+                    incident_summary(item)
+                    for item in (data.get("incidents") or [])[:20]
+                ],
+            }
+            return self._format_result(
+                f"OutageDeck service status: {slug}",
+                payload,
+                normalized,
+                campaign_url(f"/services/{slug}"),
+            )
+        finally:
+            await emit_status(__event_emitter__, "Service status finished", done=True)


### PR DESCRIPTION
## What this adds

Adds a zero-key, read-only OutageDeck tool for provider outage triage in Open WebUI. Models can:

- find monitored providers by name, health, or category
- inspect a provider's current status, source freshness, services, and active incidents
- list active or resolved incidents with provider and severity filters
- retrieve a bounded incident update timeline
- inspect component-level service status and incident history

The README includes configuration, example prompts, and the no-account setup path.

## Safety and response design

- fixed HTTPS API origin (`https://outagedeck.com/api/v1`)
- lowercase slug validation before any request
- enum and pagination bounds
- request timeout and redirects disabled
- no credentials or write operations
- bounded, normalized JSON rather than entire upstream payloads
- attributable source links so users can verify model answers

## Validation

- `python -m pytest -q tests --ignore=tests/test_minimax_pipe_integration.py` — 44 passed
- `python -m ruff check tools/outagedeck_status_tool.py tests/test_outagedeck_status_tool.py` — passed
- `python -m ruff format --check tools/outagedeck_status_tool.py tests/test_outagedeck_status_tool.py` — passed
- `python -m py_compile tools/outagedeck_status_tool.py` — passed
- `git diff --check` — passed
- live production smoke — provider search, provider detail, incident list, incident timeline, and service detail all returned normalized results

This contribution was prepared with AI assistance and validated against the live public API.
