### PR TITLE
feat: add SerpBase Google Search tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository contains **20+ specialized tools and functions** designed to enh
 
 - **arXiv Search** - Academic paper discovery (no API key required!)
 - **Perplexica Search** - Web search using Perplexica API with citations
+- **SerpBase Google Search** - Google web search with organic results, featured snippets, and AI Overviews (no self-hosted instance needed)
 - **Pexels Media Search** - High-quality photos and videos from Pexels API
 - **YouTube Search & Embed** - Search YouTube and play videos in embedded player
 - **Xquik X Data Tool** - Search and look up X posts, users, timelines, and trends
@@ -141,6 +142,7 @@ Most tools are designed to work with minimal configuration. Key configuration ar
 37. [License](#license)
 38. [Credits](#credits)
 39. [Support](#support)
+40. [SerpBase Google Search Tool](#serpbase-google-search-tool)
 ---
 
 ## 🧪 Tools
@@ -1741,6 +1743,29 @@ Checks if an assistant's message ends with an unclosed or incomplete "thinking" 
 ### Why this matters
 
 This approach allows you to leverage state-of-the-art image and music generation/editing models with full control and customization, directly from Open WebUI.
+
+---
+
+### SerpBase Google Search Tool
+
+### Description
+
+Google web search via the [SerpBase API](https://serpbase.dev) — organic results, featured snippets, and AI Overviews returned as clean JSON. No browser automation, no CAPTCHA handling, and no self-hosted instance required.
+
+### Configuration
+
+- **SERPBASE_API_KEY**: SerpBase API key (required). Get 100 free searches at https://serpbase.dev — no credit card required.
+- **MAX_RESULTS**: Maximum number of organic results to return (default: 10, max: 20)
+- **LANGUAGE**: Google interface language code, e.g. `en`, `de`, `ja` (default: `en`)
+- **COUNTRY**: Google country region code, e.g. `us`, `de`, `uk` (default: `us`)
+
+### Usage
+
+- **Example:** `Search Google for the latest Open WebUI release notes`
+
+- Returns up to 10 organic results with title, link, and snippet, plus the featured snippet and AI Overview when Google shows them.
+- Results are returned as markdown with citation events, so Open WebUI can link sources.
+- The tool degrades gracefully: without an API key it returns a clear setup message instead of failing.
 
 ---
 

--- a/tools/serpbase_search_tool.py
+++ b/tools/serpbase_search_tool.py
@@ -1,0 +1,251 @@
+"""
+title: SerpBase Google Search Tool
+description: Google web search via the SerpBase API - organic results, featured snippets and AI Overviews in clean JSON. No browser, no CAPTCHAs, no self-hosted instance needed.
+author: gefsikatsinelou
+author_url: https://github.com/gefsikatsinelou
+funding_url: https://github.com/Haervwe/open-webui-tools
+version: 1.0.0
+license: MIT
+"""
+
+import aiohttp
+from typing import Any, Optional, Callable, Awaitable
+from pydantic import BaseModel, Field
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+SERPBASE_API_URL = "https://api.serpbase.dev/google/search"
+
+
+async def emit_status(
+    event_emitter: Optional[Callable[[Any], Awaitable[None]]],
+    description: str,
+    done: bool = False,
+) -> None:
+    """Helper to emit status events."""
+    if event_emitter:
+        await event_emitter(
+            {"type": "status", "data": {"description": description, "done": done}}
+        )
+
+
+async def emit_citation(
+    event_emitter: Optional[Callable[[Any], Awaitable[None]]],
+    document: str,
+    source_url: str,
+    source_name: str,
+) -> None:
+    """Helper to emit citation events."""
+    if event_emitter:
+        await event_emitter(
+            {
+                "type": "citation",
+                "data": {
+                    "document": [document],
+                    "metadata": [{"source": source_url}],
+                    "source": {"name": source_name},
+                },
+            }
+        )
+
+
+def _format_organic(results: list[dict]) -> str:
+    """Format organic results as a markdown list."""
+    lines = []
+    for i, r in enumerate(results, start=1):
+        title = r.get("title", "").strip()
+        link = r.get("link") or r.get("url") or ""
+        snippet = (r.get("snippet") or "").strip()
+        if title:
+            lines.append(f"{i}. **{title}**")
+        else:
+            lines.append(f"{i}. {link}")
+        if link:
+            lines.append(f"   {link}")
+        if snippet:
+            lines.append(f"   {snippet}")
+    return "\n".join(lines)
+
+
+def _format_featured_snippet(fs: dict) -> str:
+    """Format the featured snippet answer card."""
+    answer = (fs.get("answer") or fs.get("snippet") or "").strip()
+    if not answer:
+        return ""
+    source = fs.get("source") or {}
+    title = (source.get("title") or "").strip()
+    link = source.get("link") or ""
+    out = f"> {answer}"
+    if title and link:
+        out += f"\n> — [{title}]({link})"
+    return out
+
+
+class Tools:
+    class Valves(BaseModel):
+        SERPBASE_API_KEY: str = Field(
+            default="",
+            description="SerpBase API key. Get 100 free searches at https://serpbase.dev (no credit card required)",
+            json_schema_extra={"input": {"type": "password"}},
+        )
+        MAX_RESULTS: int = Field(
+            default=10,
+            description="Maximum number of organic results to return (1-20)",
+            ge=1,
+            le=20,
+        )
+        LANGUAGE: str = Field(
+            default="en",
+            description="Google interface language (hl), e.g. en, de, es, fr, ja",
+        )
+        COUNTRY: str = Field(
+            default="us",
+            description="Google country region (gl), e.g. us, de, uk, jp",
+        )
+
+    def __init__(self):
+        self.valves = self.Valves()
+        self.citation = False
+
+    async def google_search(
+        self,
+        query: str,
+        num_results: Optional[int] = None,
+        language: Optional[str] = None,
+        country: Optional[str] = None,
+        __user__: Optional[dict] = None,
+        __event_emitter__: Optional[Callable[[Any], Awaitable[None]]] = None,
+    ) -> str:
+        """
+        Search Google via the SerpBase API and return organic results, featured snippets and AI Overviews in markdown.
+
+        Args:
+            query: The search query (e.g. "openai realtime api pricing")
+            num_results: Number of organic results to return (overrides the MAX_RESULTS valve, 1-20)
+            language: Google interface language code (overrides the LANGUAGE valve, e.g. "en")
+            country: Google country region code (overrides the COUNTRY valve, e.g. "us")
+
+        Returns:
+            Markdown-formatted search results with links and snippets
+        """
+        api_key = self.valves.SERPBASE_API_KEY
+        if not api_key:
+            await emit_status(
+                __event_emitter__,
+                "SerpBase API key not set - add SERPBASE_API_KEY in the tool valves",
+                done=True,
+            )
+            return (
+                "SerpBase API key is not set. Add your key in the tool's valves "
+                "(SERPBASE_API_KEY). You can get 100 free searches at https://serpbase.dev."
+            )
+
+        num = num_results or self.valves.MAX_RESULTS
+        hl = language or self.valves.LANGUAGE
+        gl = country or self.valves.COUNTRY
+
+        await emit_status(__event_emitter__, f"Searching Google for: {query}")
+
+        payload = {"q": query, "num": num, "hl": hl, "gl": gl}
+        headers = {
+            "Content-Type": "application/json",
+            "X-API-Key": api_key,
+            "User-Agent": "open-webui-tools/1.0",
+        }
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    SERPBASE_API_URL, json=payload, headers=headers, timeout=30
+                ) as response:
+                    if response.status != 200:
+                        error_msg = (
+                            f"SerpBase API returned HTTP {response.status}. "
+                            "Check your API key and quota at https://serpbase.dev/dashboard/api-keys."
+                        )
+                        logger.error(error_msg)
+                        await emit_status(__event_emitter__, error_msg, done=True)
+                        return error_msg
+                    data = await response.json()
+
+            # SerpBase returns HTTP 200 with a business status code even for failures
+            if data.get("status") != 0:
+                error_msg = (
+                    f"SerpBase API error: {data.get('error', 'unknown error')} "
+                    f"(status {data.get('status')}). Check your key and quota at "
+                    "https://serpbase.dev/dashboard/api-keys."
+                )
+                logger.error(error_msg)
+                await emit_status(__event_emitter__, error_msg, done=True)
+                return error_msg
+
+            organic = data.get("organic") or []
+            featured = data.get("featured_snippet") or {}
+            ai_overview = data.get("ai_overview") or {}
+
+            if not organic and not featured and not ai_overview:
+                await emit_status(
+                    __event_emitter__, "No results found for the query", done=True
+                )
+                return "No results found for the given query."
+
+            parts = []
+
+            if ai_overview:
+                overview_text = (
+                    ai_overview.get("content")
+                    or ai_overview.get("answer")
+                    or ai_overview.get("text")
+                    or ""
+                ).strip()
+                if overview_text:
+                    parts.append(f"## AI Overview\n\n{overview_text}")
+
+            if featured:
+                fs_text = _format_featured_snippet(featured)
+                if fs_text:
+                    parts.append(f"## Featured Snippet\n\n{fs_text}")
+
+            if organic:
+                parts.append(f"## Search Results\n\n{_format_organic(organic[:num])}")
+
+            result = "\n\n".join(parts)
+
+            # Emit citations for the organic results
+            if __event_emitter__:
+                doc_parts = []
+                for r in organic[:num]:
+                    title = r.get("title", "").strip()
+                    link = r.get("link") or r.get("url") or ""
+                    snippet = (r.get("snippet") or "").strip()
+                    entry = title or link
+                    if snippet:
+                        entry += f"\n{snippet}"
+                    doc_parts.append(entry)
+                if doc_parts:
+                    await emit_citation(
+                        __event_emitter__,
+                        "\n\n".join(doc_parts),
+                        f"https://www.google.com/search?q={query.replace(' ', '+')}",
+                        f"Google search: {query}",
+                    )
+
+            await emit_status(
+                __event_emitter__,
+                f"Found {len(organic)} results for: {query}",
+                done=True,
+            )
+            return result
+
+        except aiohttp.ClientError as e:
+            error_msg = f"Network error while calling SerpBase API: {str(e)}"
+            logger.error(error_msg)
+            await emit_status(__event_emitter__, error_msg, done=True)
+            return error_msg
+        except Exception as e:
+            error_msg = f"Error during Google search: {str(e)}"
+            logger.error(error_msg)
+            await emit_status(__event_emitter__, error_msg, done=True)
+            return error_msg


### PR DESCRIPTION
## Summary
Adds a Google web search tool backed by the [SerpBase API](https://serpbase.dev) — organic results, featured snippets and AI Overviews returned as clean JSON. No browser automation, no CAPTCHA handling, no self-hosted instance needed (unlike the Perplexica tool, which requires a `base_url` valve).

Follows up on #89 where you kindly greenlit this.

## Changes
- **New**: `tools/serpbase_search_tool.py` — single-file tool mirroring the `wiki_search_tool.py` / `pexels_image_search_tool.py` patterns:
  - `SERPBASE_API_KEY` valve (password input), plus `MAX_RESULTS`, `LANGUAGE`, `COUNTRY` valves
  - POST JSON + `X-API-Key` header per the current serpbase.dev API contract (verified against live docs)
  - Handles the API's business error envelope (HTTP 200 + `status != 0`) and HTTP errors separately
  - Status + citation events so Open WebUI links sources
  - Graceful degradation: with no key set it returns a clear setup message instead of failing
- **Updated**: `README.md` — tool list entry, TOC entry, and a documentation section

## Design decisions
| Decision | Rationale |
|----------|-----------|
| API key via valve | Matches the Pexels tool's `PEXELS_API_KEY` pattern |
| `aiohttp` only, no new deps | Already used by the wiki and Pexels tools |
| `google_search` as the tool name | Mirrors `search_wiki` / `search_photos` naming |
| AI Overview + featured snippet included | Both come back in the same JSON call at no extra cost |

## Testing
- Missing key → friendly setup message, no crash
- Success path → markdown results with citations (verified with a mocked response matching the live API shape)
- Error envelope (status != 0) and HTTP error paths → clear error messages
- `python3 -m py_compile` clean; no test suite exists in the repo

Happy to iterate on your UI/UX + security pass — as promised in #89.